### PR TITLE
mailbox: Remove the WithTimeoutConsume middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A potpourri of go modules that are useful across projects.
 
 - `tx`: The transaction module adds various wrappers over `sql.Tx`, notably
   `tx.Transactor` a transaction manager.
-- `mailbox`: The mailbox module expose the `Mailbox` and `Processor`, which allows
+- `mailbox`: The mailbox module expose the `Mailbox` and `Consumer`, which allows
   implementing the [outbox pattern](https://microservices.io/patterns/data/transactional-outbox.html) and more.
 
 ## Testing


### PR DESCRIPTION
Adds support for a timeout in the retry policy. This removes the need for the WithTimeoutConsume middleware. The WithRetryPolicyConsume now has a new field, AttemptTimeout, that controls the timeout for each attempt. It also recovers from panics and return an error.