### PR TITLE
mailbox: Fix consumer message metadata

### DIFF
--- a/mailbox/internal/metadata.go
+++ b/mailbox/internal/metadata.go
@@ -17,6 +17,9 @@ func (m *Metadata) Value() (driver.Value, error) {
 }
 
 func (m *Metadata) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
 	b, ok := value.([]byte)
 	if !ok {
 		return errors.New("type assertion to []byte failed")


### PR DESCRIPTION
The consumer was not scanning the metadata column of the mailbox table when claiming a message. This commit fixes the issue by adding the metadata column to the claim statement and scanning the value into a `map[string]string` before converting it to a `Metadata` type. This tested by adding a new test case to the consumer integration test.