### PR TITLE
tx: Simplify NewTransactor options

### DIFF
--- a/e2e/mailbox/consumer_it_test.go
+++ b/e2e/mailbox/consumer_it_test.go
@@ -18,7 +18,7 @@ func TestConsumer(t *testing.T) {
 	var (
 		ctx        = context.Background()
 		db, err    = pg.Open("pgx")
-		transactor = tx.NewTransactor(db)
+		transactor = tx.NewTransactor(db, tx.TransactorOptions{})
 		table      = createMailboxTable(t, db)
 		m          = mailbox.NewMailbox(table)
 	)


### PR DESCRIPTION
The functional option pattern is not very useful for this case. It is easier to just use a struct with fields for the options. This commit simplifies the NewTransactor function and the TransactorOptions struct.